### PR TITLE
Read username/password from .env file, accepts self-signed certs

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,11 +1,22 @@
 const httpProxy = require('http-proxy');
+const dotenv = require("dotenv");
 
 module.exports = function ({
     resources,
     options
 }) {
-    const proxy = new httpProxy.createProxyServer();
+    const proxy = new httpProxy.createProxyServer( {secure:false} );
     const routing = options.configuration;
+
+
+    // Call dotenv, so that contents in the file are stored in the environment variables
+    dotenv.config();
+
+    const env = {
+        username: process.env.PROXY_USERNAME || process.env.proxy_username,
+        password: process.env.PROXY_PASSWORD || process.env.proxy_password
+    };
+
     return function (req, res, next) {
         res.header('Access-Control-Allow-Origin', '*');
         res.header('Access-Control-Allow-Credentials', 'true');
@@ -31,7 +42,7 @@ module.exports = function ({
         if (routing.debug) {
             console.log(req.method + ' (redirect): ' + routing[dirname].target + req.url);
         }
-        proxy.web(req, res, { target: routing[dirname].target, auth: routing[dirname].auth.user + ":" + routing[dirname].auth.pass }, function (err) {
+        proxy.web(req, res, { target: routing[dirname].target, auth: env.username + ":" + env.password }, function (err) {
             if (err) {
                 next(err);
             }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/lemaiwo/ui5-middleware-route-proxy.git"
   },
   "dependencies": {
-    "http-proxy": "^1.18.0"
+    "http-proxy": "^1.18.0",
+    "dotenv": "^8.2.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,11 @@ server:
       debug: true
       routeRootPath: 
         target: http(s)://host:port
-        auth:
-          user: Username
-          pass: Password!
+```
+
+3. configure a in `.env` file with your username and password for the proxy:
+
+```yaml
+PROXY_USERNAME=<username>
+PROXY_PASSWORD=<password>
 ```

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ server:
         target: http(s)://host:port
 ```
 
-3. configure a in `.env` file with your username and password for the proxy:
+3. Add a `.env` file with your username and password for the proxy:
 
 ```yaml
 PROXY_USERNAME=<username>


### PR DESCRIPTION
Updates:

* read username and password from .env file using the "dotenv" module
* set parameter "secure" to false to allow self-signed certificates

I use your middleware to connect to a SAP backend server over HTTPS - these small changes makes it easier and more secure I believe. I thought I might as well create a pull request for your repo instead of creating yet another proxy middleware :)

regards
Frank