### PR TITLE
Allow use of dedicated Authorization header & additional http-proxy parameters

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -28,7 +28,7 @@ module.exports = function ({
         }
         // Check whether to intercept the call
         var dirname = Object.keys(routing).filter(sPath => req.url.startsWith(sPath))
-      
+
         if (dirname.length === 0 || !routing[dirname[0]]) {
             if (routing.debug) {
                 console.log(req.method + ': ' + req.url);
@@ -36,7 +36,7 @@ module.exports = function ({
             next();
             return;
         }
-        
+
         dirname = dirname[0];
         // Adjust if we need to replace the path
         req.url = (routing[dirname].replacePath) ? req.url.replace(dirname, "") : req.url
@@ -49,15 +49,15 @@ module.exports = function ({
             req.url = req.url + client;
         }
 
-		let proxyOptions = {};
-		
-		//get target
+        let proxyOptions = {};
+        
+        //get target
         let envOrDirectTarget; 
         envOrDirectTarget = process.env[routing[dirname].target] || routing[dirname].target;
         if (routing.debug) {            
             console.log(req.method + ' (redirect): ' + envOrDirectTarget + req.url);
         }
-		proxyOptions.target = envOrDirectTarget;
+        proxyOptions.target = envOrDirectTarget;
 
         //get specific auth for given service
         if(routing[dirname].auth){
@@ -65,24 +65,24 @@ module.exports = function ({
                 username = process.env[routing[dirname].auth.user]   || routing[dirname].auth.user;
                 password = process.env[routing[dirname].auth.pass]   || routing[dirname].auth.pass;
             if(header){
-            	proxyOptions.headers = { Authorization: header };
-            	if (routing.debug) {            
-		            console.log(req.method + ' (redirect): Using dedicated Authorization Header');
-		        }
+                proxyOptions.headers = { Authorization: header };
+                if (routing.debug) {            
+                    console.log(req.method + ' (redirect): Using dedicated Authorization Header');
+                }
             }else{
-            	proxyOptions.auth = username + ":" + password;
-            	if (routing.debug) {            
-		            console.log(req.method + ' (redirect): Using user & pass for BasicAuthentication');
-		        }
+                proxyOptions.auth = username + ":" + password;
+                if (routing.debug) {            
+                    console.log(req.method + ' (redirect): Using user & pass for BasicAuthentication');
+                }
             }
         }
 
-		// additional proxy settings
-		let changeOrigin = process.env[routing[dirname].auth.changeOrigin] || routing[dirname].changeOrigin;
-		if(changeOrigin){
-			proxyOptions.changeOrigin = changeOrigin;
-		}
-		
+        // additional proxy settings
+        let changeOrigin = process.env[routing[dirname].auth.changeOrigin] || routing[dirname].changeOrigin;
+        if(changeOrigin){
+            proxyOptions.changeOrigin = changeOrigin;
+        }
+
         proxy.web(req, res, proxyOptions, function (err) {
             if (err) {
                 next(err);

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -48,20 +48,42 @@ module.exports = function ({
             client += "sap-client=" +routing[dirname].auth.client;
             req.url = req.url + client;
         }
+
+		let proxyOptions = {};
+		
+		//get target
         let envOrDirectTarget; 
         envOrDirectTarget = process.env[routing[dirname].target] || routing[dirname].target;
         if (routing.debug) {            
             console.log(req.method + ' (redirect): ' + envOrDirectTarget + req.url);
         }
+		proxyOptions.target = envOrDirectTarget;
 
-        //get specific user/pass for given service
-        let username,password;
+        //get specific auth for given service
         if(routing[dirname].auth){
-            username = process.env[routing[dirname].auth.user] || routing[dirname].auth.user;
-            password = process.env[routing[dirname].auth.pass] || routing[dirname].auth.pass;      
-        }    
+            let header   = process.env[routing[dirname].auth.header] || routing[dirname].auth.header;
+                username = process.env[routing[dirname].auth.user]   || routing[dirname].auth.user;
+                password = process.env[routing[dirname].auth.pass]   || routing[dirname].auth.pass;
+            if(header){
+            	proxyOptions.headers = { Authorization: header };
+            	if (routing.debug) {            
+		            console.log(req.method + ' (redirect): Using dedicated Authorization Header');
+		        }
+            }else{
+            	proxyOptions.auth = username + ":" + password;
+            	if (routing.debug) {            
+		            console.log(req.method + ' (redirect): Using user & pass for BasicAuthentication');
+		        }
+            }
+        }
 
-        proxy.web(req, res, { target: envOrDirectTarget, auth: username + ":" + password }, function (err) {
+		// additional proxy settings
+		let changeOrigin = process.env[routing[dirname].auth.changeOrigin] || routing[dirname].changeOrigin;
+		if(changeOrigin){
+			proxyOptions.changeOrigin = changeOrigin;
+		}
+		
+        proxy.web(req, res, proxyOptions, function (err) {
             if (err) {
                 next(err);
             }

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ npm install ui5-middleware-route-proxy --save-dev
     - user: `string`
     - pass: `string` 
     - client: `string` optional. If the client is not the default client on the SAP system
-    - header: `string` optional. If given, the value is used as value for the `Authorization` header. `user` and `pass` values are not used in this case.
+    - header: `string` optional. Is used as value for the `Authorization` header if available. `user` and `pass` values are not used in this case.
   - changeOrigin: `boolean` optional. If provided, the value will be added to the [options of the http-proxy](https://www.npmjs.com/package/http-proxy#options).
   
 Each `boolean` or `string` field in a root path object can either represent the actual value or the name of a parameter in a .env file. 

--- a/readme.md
+++ b/readme.md
@@ -16,14 +16,15 @@ npm install ui5-middleware-route-proxy --save-dev
   used to match and forward requests to your server
   - target: `string`
     hostname of your backend server
-    replacePath: `string` optional. If the request path needs to be modified by taking out the root directory uri
+  - replacePath: `string` optional. If the request path needs to be modified by taking out the root directory uri
   - auth: `object`
     authorization object with username and password
     - fromEnv: `boolean` optional. If _true_ user and pass represents existing variables in _.env_ file for that specific target
     - user: `string`
     - pass: `string` 
     - client: `string` optional. If the client is not the default client on the SAP system
-    
+    - header: `string` optional. If given, the value is used as value for the `Authorization` header. `user` and `pass` values are not used in this case.
+  - changeOrigin: `boolean` optional. If provided, the value will be added to the [options of the http-proxy](https://www.npmjs.com/package/http-proxy#options).
   
 Example:
 ```yml
@@ -34,8 +35,7 @@ Example:
         auth:
           user: Username
           pass: Password!
-          client: 100
-          
+          client: 100   
 ```
 
 Example with user/pass in .env file:
@@ -49,6 +49,16 @@ Example with user/pass in .env file:
           pass: PROXY_PASSWORD
 ```
 
+Example with dedicated `Authorization` header in .env file:
+```yaml
+      debug: true
+      sap: 
+        target: http(s)://host:port
+        auth:
+          fromEnv: true
+          header: PROXY_AUTHORIZATION
+        changeOrigin: true
+```
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ npm install ui5-middleware-route-proxy --save-dev
 - debug: `boolean`
   enable logging
 - root directory of the request uri: `object`
-  used to match and forward requests to your server
+  used to match and forward requests to your server. Needs to include the leading slash  character (`/`).
   - target: `string`
     hostname of your backend server
   - replacePath: `string` optional. If the request path needs to be modified by taking out the root directory uri
@@ -29,7 +29,7 @@ npm install ui5-middleware-route-proxy --save-dev
 Example:
 ```yml
       debug: true
-      sap: 
+      /sap: 
         target: http(s)://host:port
         replacePath: true
         auth:
@@ -41,7 +41,7 @@ Example:
 Example with user/pass in .env file:
 ```yaml
       debug: true
-      sap: 
+      /sap: 
         target: http(s)://host:port
         auth:
           fromEnv: true
@@ -52,7 +52,7 @@ Example with user/pass in .env file:
 Example with dedicated `Authorization` header in .env file:
 ```yaml
       debug: true
-      sap: 
+      /sap: 
         target: http(s)://host:port
         auth:
           fromEnv: true
@@ -90,7 +90,7 @@ server:
     afterMiddleware: compression
     configuration:
       debug: true
-      routeRootPath: 
+      /routeRootPath: 
         target: http(s)://host:port
         auth:
           fromEnv: true

--- a/readme.md
+++ b/readme.md
@@ -19,13 +19,14 @@ npm install ui5-middleware-route-proxy --save-dev
   - replacePath: `string` optional. If the request path needs to be modified by taking out the root directory uri
   - auth: `object`
     authorization object with username and password
-    - fromEnv: `boolean` optional. If _true_ user and pass represents existing variables in _.env_ file for that specific target
     - user: `string`
     - pass: `string` 
     - client: `string` optional. If the client is not the default client on the SAP system
     - header: `string` optional. If given, the value is used as value for the `Authorization` header. `user` and `pass` values are not used in this case.
   - changeOrigin: `boolean` optional. If provided, the value will be added to the [options of the http-proxy](https://www.npmjs.com/package/http-proxy#options).
   
+Each `boolean` or `string` field in a root path object can either represent the actual value or the name of a parameter in a .env file. 
+
 Example:
 ```yml
       debug: true
@@ -38,24 +39,22 @@ Example:
           client: 100   
 ```
 
-Example with user/pass in .env file:
+Example with target/user/pass in .env file:
 ```yaml
       debug: true
       /sap: 
-        target: http(s)://host:port
+        target: PROXY_TARGET
         auth:
-          fromEnv: true
           user: PROXY_USERNAME
           pass: PROXY_PASSWORD
 ```
 
-Example with dedicated `Authorization` header in .env file:
+Example with target and dedicated `Authorization` header in .env file:
 ```yaml
       debug: true
       /sap: 
-        target: http(s)://host:port
+        target: PROXY_TARGET
         auth:
-          fromEnv: true
           header: PROXY_AUTHORIZATION
         changeOrigin: true
 ```
@@ -91,16 +90,16 @@ server:
     configuration:
       debug: true
       /routeRootPath: 
-        target: http(s)://host:port
+        target: PROXY_TARGET
         auth:
-          fromEnv: true
           user: PROXY_USERNAME
           pass: PROXY_PASSWORD
 ```
 
-3. Add a `.env` file with your username and password for the proxy:
+3. Add a `.env` file with your target, username and password for the proxy:
 
 ```yaml
+PROXY_TARGET=<http(s)://host:port>
 PROXY_USERNAME=<username>
 PROXY_PASSWORD=<password>
 ```


### PR DESCRIPTION
Hi Team,

thanks a ton for this tool and the relating blog. I stumbled over the blog when trying out some local development using ui5 tooling and a SCP CloudFoundry based application backend.

To support this, I have added the capability to specify a dedicated `Authorization` header instead of the basic authentication values for username and password in the configuration. This is because OAuth Tokens are required for the authentication instead of the username / password that can usually be used for ABAP based development systems. Users can then specify their access token which they have generated for themselves instead of the username / password.

I also added another option from the `http-proxy` which is needed for the SCP use case. Further settings could be added in the same way later if needed.

I also fixed some issues with the documentation that were pointed out in some issues (#9 & #10).

I hope this PR is welcome an according to your standards.

BR, Stefan