### PR TITLE
fix error thrown when proxying karma test runner

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -13,19 +13,22 @@ module.exports = function ({
     dotenv.config();
 
     return function (req, res, next) {
-        res.header('Access-Control-Allow-Origin', '*');
-        res.header('Access-Control-Allow-Credentials', 'true');
-        res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
-        res.header('Access-Control-Allow-Headers', 'X-Requested-With, Accept, Origin, Referer, User-Agent, Content-Type, Authorization, X-Mindflash-SessionID');
-        // intercept OPTIONS method
-        if ('OPTIONS' === req.method) {
-            res.header(200);
-            if (routing.debug) {
-                console.log(req.method + '(options): ' + req.url);
+        if (req.header) {
+            res.header('Access-Control-Allow-Origin', '*');
+            res.header('Access-Control-Allow-Credentials', 'true');
+            res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE');
+            res.header('Access-Control-Allow-Headers', 'X-Requested-With, Accept, Origin, Referer, User-Agent, Content-Type, Authorization, X-Mindflash-SessionID');
+            // intercept OPTIONS method
+            if ('OPTIONS' === req.method) {
+                res.header(200);
+                if (routing.debug) {
+                    console.log(req.method + '(options): ' + req.url);
+                }
+                next();
+                return;
             }
-            next();
-            return;
         }
+        
         // Check whether to intercept the call
         var dirname = Object.keys(routing).filter(sPath => req.url.startsWith(sPath))
 


### PR DESCRIPTION
When running Karma test runner using this proxy, an error is thrown.

In lib/proxy.js around line 18 a method 'header' is called on res. However, Karma sends requests that don't contain this method, thus when the check occurs it throws an error.

Since the request Karma is sending don't even need the header method, I added a check to see if the method is there. If it's not, the code just skips it, allowing Karma's requests to go through without a problem.