### PR TITLE
env variable for client + readme fixes

### DIFF
--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -45,10 +45,9 @@ module.exports = function ({
         req.url = (routing[dirname].replacePath) ? req.url.replace(dirname, "") : req.url
 
         // Adjust if we need to add a client
-         if (routing[dirname].auth.client && req.url.indexOf("sap-client") === -1){
-            
+         if (routing[dirname].auth.client && req.url.indexOf("sap-client") === -1){            
             var client = (req.url.indexOf("?") > -1) ? "&" : "?";
-            client += "sap-client=" +routing[dirname].auth.client;
+            client += "sap-client=" + (process.env[routing[dirname].auth.client] || routing[dirname].auth.client);
             req.url = req.url + client;
         }
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ npm install ui5-middleware-route-proxy --save-dev
     hostname of your backend server
   - replacePath: `string` optional. If the request path needs to be modified by taking out the root directory uri
   - auth: `object`
-    authorization object with username and password
+    authorization object with username and password ( pass `false` if authorization is not required )
     - user: `string`
     - pass: `string` 
     - client: `string` optional. If the client is not the default client on the SAP system
@@ -36,7 +36,7 @@ Example:
         auth:
           user: Username
           pass: Password!
-          client: 100   
+          client: '100' 
 ```
 
 Example with target/user/pass in .env file:
@@ -47,6 +47,7 @@ Example with target/user/pass in .env file:
         auth:
           user: PROXY_USERNAME
           pass: PROXY_PASSWORD
+          client: PROXY_CLIENT
 ```
 
 Example with target and dedicated `Authorization` header in .env file:


### PR DESCRIPTION
1. Change in proxy.js is to take care of environment variable for 'client'
2. In the readme file, client value is put inside quotes. If there are no quotes, a client 001 will be interpreted as 1
3. If a configuration route does not specify 'auth',  then statements using `routing[dirname].auth.client` will throw error. Therefore in that case it was asked to specify `auth` as `false`.